### PR TITLE
feat: Add fullscreen support to glfw code path

### DIFF
--- a/src/pl.h
+++ b/src/pl.h
@@ -432,6 +432,8 @@ typedef struct _plWindowDesc
     uint32_t uMaxWidth;
     uint32_t uMinHeight;
     uint32_t uMaxHeight;
+    bool     bFullscreen;
+    uint32_t uFullscreenMonitor;
     #endif
 
 } plWindowDesc;

--- a/src/pl_main_glfw.cpp
+++ b/src/pl_main_glfw.cpp
@@ -626,13 +626,44 @@ pl_create_window(plWindowDesc tDesc, plWindow** pptWindowOut)
     plWindow* ptWindow = (plWindow*)malloc(sizeof(plWindow));
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
 
-    glfwWindowHint(GLFW_RESIZABLE, (tDesc.tFlags & PL_WINDOW_FLAG_NOT_RESIZABLE) ? GLFW_FALSE : GLFW_TRUE);
-    glfwWindowHint(GLFW_DECORATED, (tDesc.tFlags & PL_WINDOW_FLAG_UNDECORATED) ? GLFW_FALSE : GLFW_TRUE);
-    glfwWindowHint(GLFW_FLOATING,  (tDesc.tFlags & PL_WINDOW_FLAG_TOP_MOST) ? GLFW_TRUE : GLFW_FALSE);
-    glfwWindowHint(GLFW_POSITION_X,  tDesc.iXPos);
-    glfwWindowHint(GLFW_POSITION_Y,  tDesc.iYPos);
+    int iWidth = 320;
+    int iHeight = 200;
+    if (tDesc.bFullscreen)
+    {
+        glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
+        glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
+        glfwWindowHint(GLFW_FLOATING, GLFW_FALSE);
+        glfwWindowHint(GLFW_POSITION_X, 0);
+        glfwWindowHint(GLFW_POSITION_Y, 0);
 
-    ptGlfwWindow = glfwCreateWindow((int)tDesc.uWidth, (int)tDesc.uHeight, tDesc.pcTitle, NULL, NULL);
+        // When fullscreen mode is active use screen size of the target monitor and
+        // ignore values present in the window description.
+        // If target monitor cannot be resolved then fallback to minimum viable size.
+        int iMonitorCount = 0;
+        GLFWmonitor **pptMonitors = glfwGetMonitors(&iMonitorCount);
+        if (iMonitorCount > 0 && tDesc.uFullscreenMonitor < iMonitorCount)
+        {
+            const GLFWvidmode *ptMode = glfwGetVideoMode(pptMonitors[tDesc.uFullscreenMonitor]);
+            if (ptMode)
+            {
+                iWidth = (int)ptMode->width;
+                iHeight = (int)ptMode->height;
+            }
+        }
+    }
+    else
+    {
+        glfwWindowHint(GLFW_RESIZABLE, (tDesc.tFlags & PL_WINDOW_FLAG_NOT_RESIZABLE) ? GLFW_FALSE : GLFW_TRUE);
+        glfwWindowHint(GLFW_DECORATED, (tDesc.tFlags & PL_WINDOW_FLAG_UNDECORATED) ? GLFW_FALSE : GLFW_TRUE);
+        glfwWindowHint(GLFW_FLOATING,  (tDesc.tFlags & PL_WINDOW_FLAG_TOP_MOST) ? GLFW_TRUE : GLFW_FALSE);
+        glfwWindowHint(GLFW_POSITION_X,  tDesc.iXPos);
+        glfwWindowHint(GLFW_POSITION_Y,  tDesc.iYPos);
+
+        iWidth = (int)tDesc.uWidth;
+        iHeight = (int)tDesc.uHeight;
+    }
+
+    ptGlfwWindow = glfwCreateWindow(iWidth, iHeight, tDesc.pcTitle, NULL, NULL);
 
     int iMinWidth = tDesc.uMinWidth > 0 ? (int)tDesc.uMinWidth : GLFW_DONT_CARE;
     int iMaxWidth = tDesc.uMaxWidth > 0 ? (int)tDesc.uMaxWidth : GLFW_DONT_CARE;


### PR DESCRIPTION
# Summary
Implemented fullscreen support (#133) for experimental builds utilizing the GLFW code path.

## Changes

* **Monitor Selection:** Added ability for users/app code to specify a target monitor, useful for multi-screen setups.

* **Fallback Logic:** If monitor or video settings fail to resolve during initialization, the window defaults to a 320x200 resolution.

* **Window Mode:** Opted for borderless window rather than exclusive fullscreen.


## Notes

* **Desktop Integration:** The window is configured not to draw over system menu bars (Linux/macOS).

* **UX Rationale:** I chose borderless/non-exclusive mode to provide a smoother multitasking experience on modern desktops.

*Note: I am open to switching to exclusive fullscreen if that's the project preference*


### Example running on MacOS
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/5f9add13-78f7-4bce-b91f-66c57e9ec86b" />
